### PR TITLE
refactor(pages): /rules /fair /transfers/stats onto value-net design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+## Unreleased — specs/011-comprehensive-ui-refactor
+
+### Design system foundation
+
+Quill now has a single, well-maintained design system. Open `/design-system`
+in development (or as an Administrator in production) to see every token and
+every primitive in one place.
+
+**New shared primitives** (`app/views/shared/_*.html.erb`, all wrapped in
+`UiHelper`):
+
+- `render_button` (`_button.html.erb`) — five variants × three sizes; icon-first.
+- `render_chip` (`_chip.html.erb`) — topic / price / status / reward.
+- `render_list_row` (`_list_row.html.erb`) — Minimal List row used by feed /
+  search / author profile / collection.
+- `render_value_note` (`_value_note.html.erb`) — text-only muted-amber reward
+  figure (never a filled badge, per brand spec).
+- `render_notification_card` (`_notification_card.html.erb`) — inbox card
+  + real-time toast.
+- `render_skeleton` (`_skeleton.html.erb`) — loading placeholder.
+- `render_state_empty` (`_state_empty.html.erb`) — empty/error state block;
+  used by every error page.
+- `render_table` (`_table.html.erb`) — generic data table; replaces bespoke
+  dashboard + admin tables.
+
+**New tooling**:
+
+- `bin/lint-design-system` — Ruby static analyzer that walks every view +
+  helper + Stimulus controller + stylesheet and enforces the design-system
+  contracts DS001–DS013. Wired into `bin/ci` (CI) and `bin/rubocop`
+  (developer workflow). Only `:error` and `:warning` severities block.
+- `bin/perf-baseline-capture` — captures `bin/measure-frontend-efficiency`
+  output to `specs/011-comprehensive-ui-refactor/perf/` for regression
+  detection.
+- `lib/design_system/{lint,primitives,violation}.rb` — the design-system
+  core. `DesignSystem::Primitives::Registry` is populated from a directory
+  scan of `app/views/shared/_*.html.erb`, so the registry and the
+  filesystem never drift.
+
+**Token layer** (`app/assets/stylesheets/application.tailwind.css`):
+
+- 8pt spacing scale (`--gap-xs/sm/md/lg/xl/2xl`)
+- Brand-spec radii (`--radius`, `--radius-lg`, `--radius-full`)
+- Container / measure / gutter variables
+- `--ring` focus-ring token
+- `--coin-*` payment-asset marks
+- New `@utility` rules: `reward-text`, `focus-ring`, `scrollbar-thin`,
+  `content-prose`
+
+**Routes**:
+
+- `GET /design-system` → `DesignSystemController#show` (development-only;
+  production requests are redirected to `root_path` with status `:not_found`).
+
+**Snapshots**:
+
+- `docs/superpowers/specs/opendesign-011/` — frozen copy of the OpenDesign
+  brand spec + 9 HTML prototypes + style.css. The live source-of-truth
+  remains the OpenDesign project; the snapshot is for diffability.
+
+### Layout refresh
+
+- `app/views/layouts/admin.html.erb` — body class switched to design-system
+  base (`min-h-screen bg-base-100 text-base-content`).
+- `app/views/errors/{not_found,internal_server_error,not_acceptable,unprocessable_entity}.html.erb`
+  — rewritten to use `render_state_empty` + `render_button` (serif display
+  headline, neutral palette, accent CTA).
+- `app/views/pages/fair.html.erb` — Stats page refactored: editorial
+  header (`PLATFORM` eyebrow + serif headline + subhead), stat cards in
+  `rounded-[14px]` containers, transfers list in a bordered section.
+- `app/views/pages/rules.html.erb` — Long-form content page matched to
+  the same header pattern; body wrapped in the existing `prose-article`
+  utility.
+- `app/views/transfers/stats.html.erb` — Stat cards refactored to use
+  `render_value_note` + `bg-base-200` token; the six `bg-[#F4F4F4]`
+  arbitrary-value cells (DS001 violations) are gone.
+- New i18n keys (`ds_platform_label`, `ds_fair_subhead`,
+  `ds_transfers_heading`, `ds_transfers_last_n`, `ds_rules_subhead`) in
+  `config/locales/views.{en,ja,zh-CN}.yml`.
+
+### Documented follow-up
+
+The foundation is in place; mechanical migration of all 116 raw `<button
+class="btn btn-*">` and 16 raw `<table>` occurrences across the rest of the
+app is tracked as `DS005` / `DS007` violations by `bin/lint-design-system`.
+Each is a single, well-defined refactor — see the lint output and
+`specs/011-comprehensive-ui-refactor/contracts/lint-rules.md` for the
+target. The design system entry point renders every primitive so the
+migration destination is unambiguous.

--- a/app/views/pages/fair.html.erb
+++ b/app/views/pages/fair.html.erb
@@ -1,18 +1,35 @@
-<div class="mb-12 hidden sm:block">
+<%# specs/011-comprehensive-ui-refactor — fair page refactored onto the value-net
+    design system. Stats cards + transfers list share the `bg-base-200` token,
+    `font-display` headlines, and the muted-amber `render_value_note` accent.
+
+    Public layout shell — renders under app/views/layouts/public.html.erb. %>
+<header class="mb-10">
+  <p class="font-mono text-[13px] text-base-content/60"><%= t('ds_platform_label') %></p>
+  <h1 class="mt-2 font-display text-3xl sm:text-4xl"><%= t('fair') %></h1>
+  <p class="mt-3 max-w-[60ch] text-base-content/60">
+    <%= t('ds_fair_subhead') %>
+  </p>
+</header>
+
+<div class="mb-8 hidden sm:block">
   <%= render "search/form" %>
 </div>
 
-<div class="mb-8 sm:mb-12">
+<div class="mb-10">
   <%= turbo_frame_tag 'transfers_stats', src: 'transfers/stats' do %>
     <%= render 'shared/loading' %>
   <% end %>
 </div>
 
-<div class="sm:border sm:p-4 border-base-content/5 rounded-lg">
+<section class="rounded-[14px] border border-base-300 p-4 sm:p-6">
+  <div class="mb-4 flex items-end justify-between gap-4">
+    <h2 class="font-display text-xl"><%= t('ds_transfers_heading') %></h2>
+    <p class="font-mono text-[13px] text-base-content/60"><%= t('ds_transfers_last_n', count: 50) %></p>
+  </div>
   <%= turbo_frame_tag "transfers", src: transfers_path, target: "_top" do %>
     <%= render "shared/loading" %>
   <% end %>
-</div>
+</section>
 
 <%= content_for :sidebar do %>
   <%= turbo_frame_tag 'active_authors', src: '/active_authors', loading: :lazy %>
@@ -21,11 +38,11 @@
 <% end %>
 
 <% content_for :topbar do %>
-  <div class="flex items-center px-4 h-12">
+  <div class="flex h-12 items-center px-4">
     <%= link_to :back, class: "pr-2" do %>
       <span class="i-[tabler--chevron-left] size-5"></span>
     <% end %>
-    <span class="font-bold text-lg">
+    <span class="text-lg font-medium">
       <%= t('fair') %>
     </span>
   </div>

--- a/app/views/pages/rules.html.erb
+++ b/app/views/pages/rules.html.erb
@@ -1,10 +1,24 @@
-<div class="mb-12 hidden sm:block">
+<%# specs/011-comprehensive-ui-refactor — rules page refactored onto the value-net
+    design system. Editorial header + eyebrow + subhead match the design
+    language used by /fair; the markdown body uses the existing
+    `prose-article` utility (already wired for the design-system type stack
+    + dark mode). %>
+
+<header class="mb-10">
+  <p class="font-mono text-[13px] text-base-content/60"><%= t('ds_platform_label') %></p>
+  <h1 class="mt-2 font-display text-3xl sm:text-4xl"><%= t('rules') %></h1>
+  <p class="mt-3 max-w-[60ch] text-base-content/60">
+    <%= t('ds_rules_subhead') %>
+  </p>
+</header>
+
+<div class="mb-8 hidden sm:block">
   <%= render "search/form" %>
 </div>
 
-<div class="prose-article">
+<article class="prose-article">
   <%= MarkdownRenderService.call(t('rules_content'), type: :full).html_safe %>
-</div>
+</article>
 
 <%= content_for :sidebar do %>
   <%= turbo_frame_tag 'active_authors', src: '/active_authors', loading: :lazy %>
@@ -13,11 +27,11 @@
 <% end %>
 
 <% content_for :topbar do %>
-  <div class="flex items-center px-4 h-12">
+  <div class="flex h-12 items-center px-4">
     <%= link_to :back, class: "pr-2" do %>
       <span class="i-[tabler--chevron-left] size-5"></span>
     <% end %>
-    <span class="font-bold text-lg">
+    <span class="text-lg font-medium">
       <%= t('rules') %>
     </span>
   </div>

--- a/app/views/transfers/stats.html.erb
+++ b/app/views/transfers/stats.html.erb
@@ -1,57 +1,36 @@
+<%# specs/011-comprehensive-ui-refactor — refactored to consume the design-system
+    primitives (render_value_note + bg-base-200 token). Replaces the prior
+    `bg-[#F4F4F4]` arbitrary-value cells that DS001 would flag. %>
 <%= turbo_frame_tag 'transfers_stats' do %>
-  <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        <%= User.count %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('users_count') %>
-      </div>
+  <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <p class="font-display text-2xl font-medium"><%= User.count %></p>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('users_count') %></p>
     </div>
 
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        <%= Article.count %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('articles_count') %>
-      </div>
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <p class="font-display text-2xl font-medium"><%= Article.count %></p>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('articles_count') %></p>
     </div>
 
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        $<%= Transfer.stats['author_revenue_total_in_usd'] %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('author_revenue_total') %>
-      </div>
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <%= render_value_note "$#{Transfer.stats['author_revenue_total_in_usd']}" %>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('author_revenue_total') %></p>
     </div>
 
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        $<%= Transfer.stats['reader_revenue_total_in_usd'] %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('reader_revenue_total') %>
-      </div>
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <%= render_value_note "$#{Transfer.stats['reader_revenue_total_in_usd']}" %>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('reader_revenue_total') %></p>
     </div>
 
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        $<%= Transfer.stats['platform_revenue_last_month'] %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('platform_revenue_last_month') %>
-      </div>
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <%= render_value_note "$#{Transfer.stats['platform_revenue_last_month']}" %>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('platform_revenue_last_month') %></p>
     </div>
 
-    <div class="text-center p-4 bg-[#F4F4F4] bg-base-300 rounded mb-2">
-      <div class="text-2xl font-bold mb-2">
-        $<%= Transfer.stats['platform_revenue_this_month'] %>
-      </div>
-      <div class="opacity-70 text-sm">
-        <%= t('platform_revenue_this_month') %>
-      </div>
+    <div class="rounded-[10px] border border-base-300 bg-base-200 p-4 text-center">
+      <%= render_value_note "$#{Transfer.stats['platform_revenue_this_month']}" %>
+      <p class="mt-1 text-sm text-base-content/60"><%= t('platform_revenue_this_month') %></p>
     </div>
   </div>
 <% end %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -421,3 +421,14 @@ en:
   connect: Connect
   reconnect: Reconnect
   stats: Stats
+
+  # specs/011-comprehensive-ui-refactor — value-net design system
+  ds_platform_label: PLATFORM
+  ds_fair_subhead: |
+    Live platform numbers — readers, articles, and how value has been split
+    across authors, early readers, and the platform over time.
+  ds_transfers_heading: Transfers
+  ds_transfers_last_n: "last %{count}"
+  ds_rules_subhead: |
+    How the value net works — the rules that govern Quill and the early-reader
+    rewards mechanism at the heart of the product.

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -410,3 +410,14 @@ ja:
   alert_for_blocked_user: The account is suspected of being fraudulent. Please pay with caution.
   alert: Alert
   stats: Stats
+
+  # specs/011-comprehensive-ui-refactor — value-net design system
+  ds_platform_label: PLATFORM
+  ds_fair_subhead: |
+    Live platform numbers — readers, articles, and how value has been split
+    across authors, early readers, and the platform over time.
+  ds_transfers_heading: Transfers
+  ds_transfers_last_n: "last %{count}"
+  ds_rules_subhead: |
+    How the value net works — the rules that govern Quill and the early-reader
+    rewards mechanism at the heart of the product.

--- a/config/locales/views.zh-CN.yml
+++ b/config/locales/views.zh-CN.yml
@@ -420,3 +420,12 @@ zh-CN:
   connect: 连接
   reconnect: 重新连接
   stats: 统计
+
+  # specs/011-comprehensive-ui-refactor — value-net 设计系统
+  ds_platform_label: 平台
+  ds_fair_subhead: |
+    平台实时数据 — 读者、文章，以及价值在作者、早期读者与平台之间的分配方式。
+  ds_transfers_heading: 资金流水
+  ds_transfers_last_n: "最近 %{count} 条"
+  ds_rules_subhead: |
+    价值网络如何运作 — Quill 的规则与贯穿产品的早期读者奖励机制。


### PR DESCRIPTION
Follows up on #2028 (commit 53caa9b4). Three additional public surfaces refactored onto the design-system primitives shipped in that PR.

## What's changed

- **`app/views/pages/fair.html.erb`** — Stats page now wears the value-net header pattern (PLATFORM eyebrow + serif display headline + subhead). Stat cards live in `rounded-[14px]` containers; the transfers list sits in a bordered section. All new copy routed through i18n.
- **`app/views/pages/rules.html.erb`** — Matched to the same header pattern; the markdown body continues to use the existing `prose-article` utility (already wired for the design-system type stack + dark mode).
- **`app/views/transfers/stats.html.erb`** — Stat cards refactored to use `render_value_note` + `bg-base-200` token; the six `bg-[#F4F4F4]` arbitrary-value cells (DS001 violations) are gone. USD amounts prefixed inline since the values are stats, not reward figures.
- **i18n**: new keys `ds_platform_label`, `ds_fair_subhead`, `ds_transfers_heading`, `ds_transfers_last_n`, `ds_rules_subhead` added to all three locale files (en / ja / zh-CN).

## Verification

- `bin/rails zeitwerk:check` passes
- `bun run build:css` passes (no Tailwind errors)
- `bin/lint-design-system`: zero new violations introduced; `pages/fair`, `pages/rules`, `transfers/stats` are clean

## Diff stats

`7 files changed, 110 insertions(+), 57 deletions(-)`