### PR TITLE
ci: pin workflow Postgres images to pgvector/pgvector:pg16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: [self-hosted, linux]
     services:
       db:
-        image: postgres:latest
+        image: pgvector/pgvector:pg16
         ports: ['5432:5432']
         env:
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, linux, agentic]
     services:
       db:
-        image: postgres:latest
+        image: pgvector/pgvector:pg16
         ports: ['5432:5432']
         env:
           POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
## Summary

Resolves #2016 and #2019 (the latter supersedes the former — one PR covers both).

Pins the last two workflows still using `postgres:latest` to `pgvector/pgvector:pg16`, aligning CI with production and the rest of the repo's workflows:

- `.github/workflows/check.yml`: `postgres:latest` → `pgvector/pgvector:pg16`
- `.github/workflows/opencode.yml`: `postgres:latest` → `pgvector/pgvector:pg16`

## Why

- Production runs `pgvector/pgvector:pg16` (`config/deploy.yml` L65); `postgres:latest` is a moving target that drifts from it.
- The `pg_trgm` migration (`db/migrate/20260707234118_add_pg_trgm_indexes_for_search.rb`) requires contrib and explicitly declares `pgvector/pgvector:pg16` as the production image — CI should match.
- Every other workflow in the repo (test-improver, perf-improver, repo-assist, etc.) already pins a pgvector pg16 image; these two were the only remaining `postgres:latest` usages.

## Audit notes

Verified against `main` before opening:

- `grep postgres:latest .github/workflows/` matched only these two files
- `config/deploy.yml:65` confirms the production image
- Migration comment confirms contrib dependency

No Ruby/JS source touched — CI on this PR (including the `pg_trgm` migration via `bin/ci`) validates the image change.

Closes #2016
Closes #2019