### PR TITLE
fix: comments#new 500 when commentable is missing

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -33,7 +33,10 @@ class CommentsController < ApplicationController
     elsif params[:commentable_type] == "Article"
       @commentable = Article.find_by id: params[:commentable_id]
     end
-    nil if @commentable.blank?
+
+    return head :not_found if @commentable.blank?
+
+    authorize @commentable, :comment?
   end
 
   def create

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -42,4 +42,46 @@ class CommentsControllerTest < ActionController::TestCase
       }, format: :turbo_stream
     end
   end
+
+  test "new returns not found without commentable params" do
+    get :new
+
+    assert_response :not_found
+  end
+
+  test "new returns not found for unknown commentable id" do
+    get :new, params: { commentable_type: "Article", commentable_id: -1 }
+
+    assert_response :not_found
+  end
+
+  test "new returns not found for unknown quote comment id" do
+    get :new, params: { quote_comment_id: -1 }
+
+    assert_response :not_found
+  end
+
+  test "new renders form for published free article" do
+    article = articles(:published_free)
+
+    get :new, params: { commentable_type: "Article", commentable_id: article.id }
+
+    assert_response :ok
+    assert_match %r{name="comment\[commentable_id\]"}, response.body
+  end
+
+  test "new renders form for quote comment" do
+    get :new, params: { quote_comment_id: comments(:one).id }
+
+    assert_response :ok
+    assert_match %r{name="comment\[quote_comment_id\]"}, response.body
+  end
+
+  test "new rejects unauthorized articles" do
+    article = articles(:draft)
+
+    get :new, params: { commentable_type: "Article", commentable_id: article.id }
+
+    assert_redirected_to root_path
+  end
 end


### PR DESCRIPTION
## Problem

Production error on `GET /comments/new` (comments#new):

```
#<ActionView::Template::Error: undefined method 'comments' for nil>
```

`CommentsController#new` only assigns `@commentable` when params resolve to a real article or quoted comment. In every other case — no params (bots/crawlers hitting the URL directly), stale or bogus `commentable_id`/`quote_comment_id`, or `commentable_type` ≠ `"Article"` — `@commentable` stayed `nil` and the action rendered `new.html.erb` anyway. `_form.html.erb:5` then called `commentable.comments.new` on `nil`.

The dead line `nil if @commentable.blank?` was the smoking gun: git history (71e980c8) shows it was originally `return if @commentable.blank?`, which never prevented rendering either — Rails renders the default template regardless of a bare `return`. `index` in the same controller already guarded this correctly; `new` was the only path missing it.

## Fix

- `return head :not_found if @commentable.blank?` — a real 404 instead of a 500, mirroring `create`'s `return head :forbidden if commentable.blank?` convention. In the browser the modal just doesn't open; bots get a clean 404.
- `authorize @commentable, :comment?` — aligns `new` with what `create` already enforces via `CommentPolicy#create?`. Also closes a related inconsistency: the modal previously rendered for **drafted** articles to anyone, because `new` used a plain `Article.find_by` with no `published?`/`authorized?` check. Unauthorized access flows through the existing `user_not_authorized` rescue (redirect + alert).

## Tests

- no params → 404
- unknown `commentable_id` → 404
- unknown `quote_comment_id` → 404
- published article → renders comment form
- quote-comment reply → renders form with `quote_comment_id` propagated
- draft article → redirected to root

50 comment-related controller/model/policy tests pass; rubocop clean.

## Follow-up

The quote `#id` links (`comments/_comment.html.erb`, `comments/_quote_comment.html.erb`) now send logged-out users to the "Not authorized" redirect instead of a login prompt — a follow-up PR will route them to the login modal, matching the reply button behavior in `_actions.html.erb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)