### PR TITLE
fix: self-heal a corrupted Solid Cache SQLite database

### DIFF
--- a/config/initializers/solid_cache_failsafe.rb
+++ b/config/initializers/solid_cache_failsafe.rb
@@ -1,43 +1,229 @@
 # frozen_string_literal: true
 
-# Make Solid Cache tolerant of a corrupted cache database.
+# Make Solid Cache survive a corrupted cache database.
 #
 # Why this exists:
+#   The cache lives in a SQLite file (storage/production_cache.sqlite3) that
+#   every long-running process shares through the deploy volume (web, jobs and
+#   blaze all mount /rails/storage — see config/deploy.yml). A hard kill
+#   mid-write during a deploy can leave that file with a malformed disk image,
+#   after which every query touching the damaged pages raises
+#   SQLite3::CorruptException, wrapped by ActiveRecord as
+#   ActiveRecord::StatementInvalid.
+#
+# Layer 1 — degrade gracefully:
 #   Solid Cache's upstream Failsafe only rescues a small, hardcoded list of
-#   "transient" ActiveRecord errors (timeouts, deadlocks, lost connections).
-#   It does NOT rescue ActiveRecord::StatementInvalid, which is the wrapper
-#   ActiveRecord puts around the native SQLite3::CorruptException raised when
-#   the cache database file is malformed.
+#   "transient" ActiveRecord errors. It does NOT rescue
+#   ActiveRecord::StatementInvalid, so a read/write against a corrupt file
+#   500'd the request (the error bubbled up through ActionView's `cache`
+#   helper, see app/views/articles/_widgets.html.erb) even though a cache miss
+#   would be a perfectly fine fallback. The prepended module below expands the
+#   rescue list; rescued errors flow into the store's error_handler installed
+#   at the bottom of this file.
 #
-#   When the cache database gets corrupted (typically because the container
-#   is SIGKILL'd mid-write during a deploy or auto-scale), every read/write/
-#   delete call therefore raises an unhandled error. The error bubbles up
-#   through ActionView's `cache` helper (see app/views/articles/_widgets.html.erb)
-#   and 500s the request, even though a cache miss would be a perfectly fine
-#   fallback.
+# Layer 2 — heal the corruption (the root-cause fix):
+#   Nothing ever repaired the file, so the error repeated forever and the cache
+#   stayed dead until an operator deleted it by hand. Notably the background
+#   expiry thread (Store::Expiry#expire_later → Entry.expire) is NOT wrapped in
+#   Failsafe — it re-raised the corruption on every cache write, which is the
+#   unhandled stack trace behind this error. So we:
+#     * install an `error_handler` on the store — the single choke point that
+#       both Failsafe and the expiry thread report through — which reports each
+#       failure to Rails.error and detects corruption via the exception's
+#       cause chain;
+#     * on corruption, rebuild the database (flock-guarded across the processes
+#       sharing the volume; a cache is disposable, so dropping it is safe);
+#     * run a cheap `PRAGMA quick_check` at boot — before bin/docker-entrypoint's
+#       `db:prepare` and before any traffic — so an already-corrupt file is
+#       healed deterministically on the next deploy.
 #
-# What this does:
-#   - Prepends a module on SolidCache::Store::Failsafe that expands the rescue
-#     list to include ActiveRecord::StatementInvalid.
-#   - For rescued errors we report to Rails.error (so the corruption is
-#     observable) and let SolidCache's existing error_handler run.
-#   - Returns the failsafe_returning value (nil / false / 0 / {}) so callers
-#     see the same fallback they would for any other transient error: a
-#     cache miss on read, a no-op on write, etc.
+# This file is intentionally self-contained (the module is defined here rather
+# than in lib/): the wiring below has to run via `after_initialize`, because
+# Rails does not set up the autoloaders until after all initializers have run
+# (Application::Finisher#setup_main_autoloader) — neither lib/ nor the gem's
+# own models are referenceable in initializer file scope.
 module SolidCacheFailsafeStatementInvalidExt
   def failsafe(method, returning: nil)
     yield
-  rescue *extended_rescue_list, ActiveRecord::StatementInvalid => error
-    ActiveSupport.error_reporter&.report(error, handled: true, severity: :warning,
-                                                    context: { cache_method: method, cache_store: "SolidCache" })
+  rescue *SolidCache::Store::Failsafe::TRANSIENT_ACTIVE_RECORD_ERRORS,
+         ActiveRecord::StatementInvalid => error
     error_handler&.call(method: method, exception: error, returning: returning)
     returning
   end
-
-  private
-    def extended_rescue_list
-      SolidCache::Store::Failsafe::TRANSIENT_ACTIVE_RECORD_ERRORS
-    end
 end
 
 SolidCache::Store::Failsafe.prepend(SolidCacheFailsafeStatementInvalidExt)
+
+# Self-healing for a corrupted Solid Cache SQLite database.
+#
+# Every path here only ever touches the `cache` database pool — never primary,
+# cable or queue.
+module SolidCacheRecovery
+  # If the filesystem itself is broken, a rebuild attempt after every cache
+  # write would be worse than the corruption. Failed attempts are throttled too.
+  MIN_RECOVERY_INTERVAL = 60
+
+  # SQLITE_CORRUPT ("database disk image is malformed") and SQLITE_NOTADB
+  # ("file is not a database" — zeroed-out or truncated file) both mean the
+  # file itself is unusable, as opposed to transient lock/timeout errors.
+  RECOVERABLE_SQLITE_ERRORS = [SQLite3::CorruptException, SQLite3::NotADatabaseException].freeze
+
+  # Installed as the Solid Cache store's `error_handler` at the bottom of this
+  # file. Solid Cache routes every error it handles itself through this one
+  # hook — both the Failsafe-wrapped request reads/writes and the unwrapped
+  # background expiry thread — which makes it the single choke point where
+  # corruption is detected and repaired.
+  ERROR_HANDLER = ->(method:, returning:, exception:) do
+    Rails.error&.report(exception, handled: true, severity: :warning,
+                                    context: { cache_method: method, cache_store: "SolidCache" })
+    Rails.logger&.error("SolidCacheStore: #{method} failed, returned #{returning.inspect}: " \
+                       "#{exception.class}: #{exception.message}")
+
+    SolidCacheRecovery.recover!(reason: "cache #{method} failed") if SolidCacheRecovery.corrupt_exception?(exception)
+  end
+
+  @recovery_mutex = Mutex.new
+  @last_recovery_at = nil
+
+  class << self
+    def check_at_boot!
+      return unless sqlite_cache?
+      return unless File.exist?(db_path.to_s)
+
+      healthy =
+        begin
+          cache_pool.with_connection { |connection| connection.select_value("PRAGMA quick_check(1)") } == "ok"
+        rescue StandardError
+          false # A file too broken to even run quick_check on is corrupt by definition.
+        end
+
+      recover!(reason: "quick_check failed at boot") unless healthy
+    rescue StandardError => error
+      report_recovery_failure(error, "boot integrity check")
+    end
+
+    def recover!(reason:)
+      return unless sqlite_cache?
+      return unless recovery_due?
+
+      @recovery_mutex.synchronize do
+        return unless recovery_due? # Re-check: another thread may have just repaired.
+
+        with_repair_lock do |acquired|
+          # Another process sharing the volume is already rebuilding; its
+          # schema load is this process's repair too.
+          next unless acquired
+
+          rebuild_database!
+          @last_recovery_at = monotonic_now
+          Rails.logger&.info("[SolidCacheRecovery] rebuilt corrupt cache database at #{db_path} (#{reason})")
+        end
+      end
+    rescue StandardError => error
+      @last_recovery_at = monotonic_now
+      report_recovery_failure(error, "cache database rebuild")
+    end
+
+    def corrupt_exception?(exception)
+      while exception
+        return true if RECOVERABLE_SQLITE_ERRORS.any? { |klass| exception.is_a?(klass) }
+        exception = exception.cause
+      end
+      false
+    end
+
+    private
+      def rebuild_database!
+        pool = cache_pool
+        pool.disconnect! # Connections may still hold the corrupt file's inode open.
+        remove_database_files!
+        load_schema_against_cache_pool!
+      end
+
+      def remove_database_files!
+        [db_path, "#{db_path}-wal", "#{db_path}-shm", "#{db_path}-journal"].each do |file|
+          File.delete(file) if File.exist?(file)
+        end
+      end
+
+      # Recreates the schema by loading db/cache_schema.rb against the *cache*
+      # pool. `ActiveRecord::Schema#define` resolves its connection through
+      # `ActiveRecord::Tasks::DatabaseTasks.migration_class`, so that is pointed
+      # at the cache model for the duration of the load — the same targeting
+      # Rails' own `db:prepare` uses (see DatabaseTasks#with_temporary_pool),
+      # but scoped to the cache model instead of clobbering ActiveRecord::Base.
+      # Only migration/schema tooling reads that method, never request paths,
+      # so the swap is safe at runtime.
+      def load_schema_against_cache_pool!
+        tasks = ActiveRecord::Tasks::DatabaseTasks
+        target = schema_target
+        tasks.define_singleton_method(:migration_class) { target }
+        load schema_path.to_s
+      ensure
+        tasks.singleton_class.remove_method(:migration_class)
+      end
+
+      def with_repair_lock
+        File.open("#{db_path}.recovery.lock", File::CREAT | File::RDWR) do |lock|
+          # `flock` returns 0 when the lock is acquired and false when another
+          # process holds it.
+          yield lock.flock(File::LOCK_EX | File::LOCK_NB) == 0
+        end
+      end
+
+      def recovery_due?
+        @last_recovery_at.nil? || monotonic_now - @last_recovery_at >= MIN_RECOVERY_INTERVAL
+      end
+
+      def sqlite_cache?
+        cache_db_config&.adapter == "sqlite3"
+      rescue StandardError
+        false
+      end
+
+      # Kept as separate methods so tests can point them at a scratch database
+      # instead of stubbing SolidCache::Record itself.
+      def cache_db_config
+        SolidCache::Record.connection_db_config
+      end
+
+      def db_path
+        cache_db_config.configuration_hash.fetch(:database)
+      end
+
+      def cache_pool
+        SolidCache::Record.connection_pool
+      end
+
+      def schema_target
+        SolidCache::Record
+      end
+
+      def schema_path
+        Rails.root.join("db/cache_schema.rb")
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def report_recovery_failure(error, stage)
+        Rails.error&.report(error, handled: true, severity: :error,
+                                   context: { cache_store: "SolidCache", recovery_stage: stage })
+        Rails.logger&.error("[SolidCacheRecovery] #{stage} failed: #{error.class}: #{error.message}")
+      end
+  end
+end
+
+# Rails.cache was already instantiated during bootstrap (see
+# Rails::Application::Bootstrap#initialize_cache), but Solid Cache's models
+# (SolidCache::Record and friends) only become autoloadable once the finishers
+# have set the autoloaders up — so `after_initialize` is the earliest point
+# where the live store can be wired and the cache database checked. This runs
+# before bin/docker-entrypoint's `db:prepare` and before any traffic.
+Rails.application.config.after_initialize do
+  next unless Rails.cache.is_a?(SolidCache::Store)
+
+  Rails.cache.instance_variable_set(:@error_handler, SolidCacheRecovery::ERROR_HANDLER)
+  SolidCacheRecovery.check_at_boot!
+end

--- a/test/initializers/solid_cache_failsafe_test.rb
+++ b/test/initializers/solid_cache_failsafe_test.rb
@@ -15,19 +15,24 @@ require "test_helper"
 #
 # The initializer prepends a module on `SolidCache::Store::Failsafe` that
 # expands the rescue list to include `ActiveRecord::StatementInvalid` and
-# routes rescued errors through `Rails.error.report` (handled, warning).
-# These tests pin both behaviors so a future gem upgrade or refactor can't
-# silently re-break the page.
+# routes rescued errors into the store's `error_handler`, which the
+# initializer sets to `SolidCacheRecovery::ERROR_HANDLER` — the choke point
+# that reports to `Rails.error` (handled, warning), logs, and rebuilds the
+# database when the error is actual corruption (see
+# test/initializers/solid_cache_recovery_test.rb). These tests pin those
+# behaviors so a future gem upgrade or refactor can't silently re-break the
+# page.
 class SolidCacheFailsafeStatementInvalidExtTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::ErrorReporterAssertions
 
   # The Solid Cache gem ships Failsafe as a module, not a class. We need a
   # concrete object to call the private `failsafe` on, so we instantiate a
-  # bare `SolidCache::Store` and reach into its included modules via
-  # `send`. (We do not actually hit SQLite — the block is responsible for
-  # raising or returning.)
+  # bare `SolidCache::Store` with the same `error_handler` the initializer
+  # injects in production and reach into its included modules via `send`.
+  # (We do not actually hit SQLite — the block is responsible for raising or
+  # returning.)
   setup do
-    @store = SolidCache::Store.new
+    @store = SolidCache::Store.new(error_handler: SolidCacheRecovery::ERROR_HANDLER)
   end
 
   test "failsafe returns the supplied default when the block raises ActiveRecord::StatementInvalid (e.g. SQLite3::CorruptException)" do

--- a/test/initializers/solid_cache_recovery_test.rb
+++ b/test/initializers/solid_cache_recovery_test.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Covers `lib/solid_cache_recovery.rb` and its wiring through
+# `config/initializers/solid_cache_failsafe.rb`.
+#
+# The recovery module exists because the production cache SQLite file can end
+# up with a malformed disk image (shared deploy volume, hard kill mid-write),
+# after which nothing ever repaired it. These tests exercise the real repair
+# against a real (deliberately corrupted) SQLite file so they would catch, for
+# example, a Rails upgrade breaking the schema-recreation trick or a sidecar
+# (-wal/-shm) no longer being cleaned up.
+#
+# The module's seams (`cache_db_config`, `cache_pool`, `schema_target`) are
+# pointed at a scratch database instead of `SolidCache::Record` so the tests
+# never touch the real cache/primary pools.
+class SolidCacheRecoveryTest < ActiveSupport::TestCase
+  SIDE_CAR_SUFFIXES = ["", "-wal", "-shm", "-journal"].freeze
+
+  setup do
+    # Unique per test so `establish_connection` always builds a fresh pool
+    # instead of reusing one that still holds a connection to a deleted file.
+    @db_path = Rails.root.join("tmp/solid_cache_recovery_test_#{SecureRandom.hex(4)}.sqlite3")
+    purge_scratch_database
+    # The throttle lives in module state and would otherwise leak between tests.
+    SolidCacheRecovery.instance_variable_set(:@last_recovery_at, nil)
+  end
+
+  teardown { purge_scratch_database }
+
+  module PoolTarget
+    def self.for(pool)
+      target = Object.new
+      target.define_singleton_method(:connection_pool) { pool }
+      target.define_singleton_method(:lease_connection) { pool.lease_connection }
+      target
+    end
+  end
+
+  # Throwaway connection owner so the global ActiveRecord::Base /
+  # SolidCache::Record connection assignments are never touched.
+  class ScratchOwner < ActiveRecord::Base
+    self.abstract_class = true
+  end
+
+  # Points SolidCacheRecovery at a scratch SQLite database for the duration of
+  # the block and yields the scratch pool.
+  def with_cache_database(path)
+    config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      "test", "cache", { adapter: "sqlite3", database: path.to_s, timeout: 5000 }
+    )
+    ScratchOwner.establish_connection(config)
+    pool = ScratchOwner.connection_pool
+
+    stubs = {
+      cache_db_config: -> { config },
+      cache_pool: -> { pool },
+      schema_target: -> { PoolTarget.for(pool) }
+    }
+    stub_seams!(stubs)
+
+    yield pool
+  ensure
+    restore_seams!(stubs || {})
+    ScratchOwner.connection_pool.disconnect!
+  end
+
+  def stub_seams!(stubs)
+    stubs.each do |name, block|
+      SolidCacheRecovery.singleton_class.alias_method(:"__original_#{name}", name)
+      SolidCacheRecovery.singleton_class.send(:define_method, name, block)
+    end
+  end
+
+  def restore_seams!(stubs)
+    stubs.each_key do |name|
+      SolidCacheRecovery.singleton_class.alias_method(name, :"__original_#{name}")
+      SolidCacheRecovery.singleton_class.remove_method(:"__original_#{name}")
+    end
+  end
+
+  # Corrupts the scratch file the way a hard kill mid-write can: garbage where
+  # the database image should be, plus a stale WAL sidecar. The pool is
+  # disconnected first so the next checkout reopens the file and actually sees
+  # the damage.
+  def corrupt_database!(pool)
+    pool.disconnect!
+    File.binwrite(@db_path, "this is not a SQLite database" * 64)
+    File.binwrite("#{@db_path}-wal", "stale write-ahead log" * 16)
+  end
+
+  def database_quick_check(pool)
+    pool.with_connection { |connection| connection.select_value("PRAGMA quick_check(1)") }
+  end
+
+  def cache_table_names(pool)
+    pool.with_connection { |connection| connection.tables }
+  end
+
+  def expire_throttle!
+    SolidCacheRecovery.instance_variable_set(
+      :@last_recovery_at,
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - SolidCacheRecovery::MIN_RECOVERY_INTERVAL - 1
+    )
+  end
+
+  def purge_scratch_database
+    SIDE_CAR_SUFFIXES.each { |suffix| FileUtils.rm_f("#{@db_path}#{suffix}") }
+    FileUtils.rm_f("#{@db_path}.recovery.lock")
+  end
+
+  test "corrupt_exception? detects corruption wrapped by ActiveRecord in the cause chain" do
+    wrapped = begin
+      begin
+        raise SQLite3::CorruptException, "database disk image is malformed"
+      rescue SQLite3::CorruptException
+        raise ActiveRecord::StatementInvalid, "SQLite3::CorruptException: database disk image is malformed"
+      end
+    rescue ActiveRecord::StatementInvalid => error
+      error
+    end
+
+    assert SolidCacheRecovery.corrupt_exception?(wrapped)
+  end
+
+  test "corrupt_exception? detects bare SQLite corruption errors" do
+    assert SolidCacheRecovery.corrupt_exception?(SQLite3::CorruptException.new("database disk image is malformed"))
+    assert SolidCacheRecovery.corrupt_exception?(SQLite3::NotADatabaseException.new("file is not a database"))
+  end
+
+  test "corrupt_exception? ignores transient and unrelated errors" do
+    transient = begin
+      raise ActiveRecord::AdapterTimeout, "could not obtain a database connection"
+    rescue ActiveRecord::AdapterTimeout => error
+      error
+    end
+
+    assert_not SolidCacheRecovery.corrupt_exception?(transient)
+    assert_not SolidCacheRecovery.corrupt_exception?(ArgumentError.new("unrelated"))
+    assert_not SolidCacheRecovery.corrupt_exception?(nil)
+  end
+
+  test "recover! rebuilds a corrupt database into a usable cache" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+
+      SolidCacheRecovery.recover!(reason: "test")
+
+      assert_equal "ok", database_quick_check(pool), "the rebuilt database must pass quick_check"
+      assert_includes cache_table_names(pool), "solid_cache_entries", "the cache schema must be recreated"
+
+      # The rebuilt cache must actually be writable and readable.
+      pool.with_connection do |connection|
+        connection.execute(<<~SQL.squish)
+          INSERT INTO solid_cache_entries (key, value, key_hash, byte_size, created_at)
+          VALUES (x'6B6579', x'76616C7565', 42, 5, '2026-01-01 00:00:00')
+        SQL
+        assert_equal 1, connection.select_value("SELECT count(*) FROM solid_cache_entries")
+      end
+    end
+  end
+
+  test "recover! removes stale -wal and -shm sidecars of the corrupt database" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+      File.binwrite("#{@db_path}-shm", "stale shared memory" * 8)
+
+      SolidCacheRecovery.recover!(reason: "test")
+
+      assert_equal "ok", database_quick_check(pool)
+    end
+  end
+
+  test "recover! is throttled to one attempt per MIN_RECOVERY_INTERVAL" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+      SolidCacheRecovery.recover!(reason: "first")
+      assert_equal "ok", database_quick_check(pool)
+
+      corrupt_database!(pool)
+      SolidCacheRecovery.recover!(reason: "second within interval")
+
+      assert File.read(@db_path).start_with?("this is not a SQLite database"),
+             "a recovery within the throttle interval must not run"
+    end
+  end
+
+  test "recover! runs again once the throttle interval has elapsed" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+      SolidCacheRecovery.recover!(reason: "first")
+      corrupt_database!(pool)
+
+      expire_throttle!
+      SolidCacheRecovery.recover!(reason: "second after interval")
+
+      assert_equal "ok", database_quick_check(pool)
+    end
+  end
+
+  test "recover! skips the rebuild when another process holds the repair lock" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+
+      File.open("#{@db_path}.recovery.lock", File::CREAT | File::RDWR) do |lock|
+        lock.flock(File::LOCK_EX)
+
+        SolidCacheRecovery.recover!(reason: "test")
+
+        assert File.read(@db_path).start_with?("this is not a SQLite database"),
+               "the rebuild must be left to the process holding the repair lock"
+      end
+    end
+  end
+
+  test "recover! is a no-op when the cache database is not SQLite" do
+    corrupt_database!(ScratchOwner.connection_pool)
+
+    postgres_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      "test", "cache", { adapter: "postgresql", database: "safety_probe" }
+    )
+
+    stub_seams!(cache_db_config: -> { postgres_config })
+    SolidCacheRecovery.recover!(reason: "test")
+    restore_seams!(cache_db_config: nil)
+
+    assert File.exist?(@db_path), "a non-SQLite cache config must never trigger the file-based rebuild"
+  end
+
+  test "check_at_boot! heals a corrupt database before traffic" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+
+      SolidCacheRecovery.check_at_boot!
+
+      assert_equal "ok", database_quick_check(pool)
+      assert_includes cache_table_names(pool), "solid_cache_entries"
+    end
+  end
+
+  test "check_at_boot! leaves a healthy database untouched" do
+    with_cache_database(@db_path) do |pool|
+      pool.with_connection { |connection| connection.create_table :boot_probe }
+
+      SolidCacheRecovery.check_at_boot!
+
+      assert_includes cache_table_names(pool), "boot_probe", "a healthy database must not be rebuilt"
+    end
+  end
+
+  test "check_at_boot! does not touch anything when the database file is missing" do
+    config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      "test", "cache", { adapter: "sqlite3", database: @db_path.to_s, timeout: 5000 }
+    )
+
+    untouched_pool = Object.new
+    untouched_pool.define_singleton_method(:with_connection) do |&block|
+      flunk "the boot check must not open the database when the file does not exist yet"
+    end
+
+    stub_seams!(cache_db_config: -> { config }, cache_pool: -> { untouched_pool })
+    SolidCacheRecovery.check_at_boot!
+    restore_seams!(cache_db_config: nil, cache_pool: nil)
+
+    assert_not File.exist?(@db_path), "a missing cache file must be left to db:prepare to create"
+  end
+
+  test "the store's error_handler reports corruption and triggers recovery" do
+    with_cache_database(@db_path) do |pool|
+      corrupt_database!(pool)
+
+      corruption = begin
+        raise SQLite3::CorruptException, "database disk image is malformed"
+      rescue SQLite3::CorruptException => error
+        error
+      end
+
+      assert_error_reported(SQLite3::CorruptException) do
+        SolidCacheRecovery::ERROR_HANDLER.call(method: :expire, returning: nil, exception: corruption)
+      end
+
+      assert_equal "ok", database_quick_check(pool), "the expiry-thread corruption must trigger the rebuild"
+    end
+  end
+
+  test "the store's error_handler does not trigger recovery for transient errors" do
+    with_cache_database(@db_path) do |pool|
+      pool.with_connection { |connection| connection.create_table :boot_probe }
+
+      transient = begin
+        raise ActiveRecord::AdapterTimeout, "could not obtain a database connection"
+      rescue ActiveRecord::AdapterTimeout => error
+        error
+      end
+
+      SolidCacheRecovery::ERROR_HANDLER.call(method: :expire, returning: nil, exception: transient)
+
+      assert_includes cache_table_names(pool), "boot_probe", "transient errors must not rebuild the cache"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

[`SQLite3::CorruptException: database disk image is malformed`](https://us.posthog.com/error_tracking/019fa17e-e5e3-7fc0-a6e9-17fcca1d570e) fired from Solid Cache's background expiry thread (`Store::Expiry#expire_later` → `Entry.expire`) on every cache write.

### Root cause

1. **Why it corrupts:** the cache lives in a single SQLite file (`storage/production_cache.sqlite3`) that the `web`, `blaze` and `job` roles all share through the deploy volume (`config/deploy.yml` mounts the same host dir into `/rails/storage`). A hard kill mid-write during a deploy (Kamal's stop timeout → SIGKILL) can leave a malformed image / inconsistent WAL sidecars.
2. **Why it never got better:** nothing ever repaired the file. The earlier `solid_cache_failsafe` initializer only expanded Solid Cache's `Failsafe` rescue list so request reads/writes degraded to cache misses — the corrupt file itself stayed broken forever.
3. **Why this specific stack:** the background expiry thread is *not* wrapped in `Failsafe`. Every cache write schedules expiry (`track_writes` → `expire_later`), so every write re-raised the corruption in that thread.

## Fix

Layer 1 (kept, simplified) degrades gracefully. The new **Layer 2 heals the corruption itself** (`SolidCacheRecovery`, defined in the initializer):

- **One choke point:** the store's `error_handler` — the hook both `Failsafe` and the expiry thread report through — reports every failure to `Rails.error` (handled/warning, still visible in PostHog) and detects corruption via the exception's cause chain (`SQLite3::CorruptException`, `SQLite3::NotADatabaseException`).
- **Self-healing rebuild:** exclusive `flock` (the volume is shared by 3 processes, no stampede) → disconnect the cache pool → delete the DB + `-wal`/`-shm`/`-journal` sidecars → recreate the schema from `db/cache_schema.rb` against the *cache pool only* (scoped by targeting `DatabaseTasks.migration_class` at `SolidCache::Record` — the same mechanism Rails' own `db:prepare` uses, without clobbering `ActiveRecord::Base`). A cache is disposable, so dropping it is always safe. Throttled to one attempt / 60 s per process; every failure is reported and swallowed so a broken filesystem can't loop.
- **Boot-time `PRAGMA quick_check(1)`** — runs via `after_initialize`, i.e. before `bin/docker-entrypoint`'s `db:prepare` and before any traffic, so an already-corrupt file is healed deterministically on the next deploy (and can no longer crash-loop the entrypoint).

### Boot-phase constraints (documented in the file)

- Initializer file scope can't autoload anything (`setup_main_autoloader` is a finisher), so the module is defined in-file.
- `Rails.cache` is instantiated during bootstrap (`Application::Bootstrap#initialize_cache`), so mutating `config.cache_store` in an initializer would have no effect — the handler is injected onto the live store.

## Testing

- `test/initializers/solid_cache_recovery_test.rb` (14 new tests) exercises the real repair against real corrupt SQLite files: rebuild + usability, sidecar cleanup, throttle, cross-process lock, non-SQLite config guard, boot check (heals / leaves healthy alone / ignores missing file), and `error_handler` wiring.
- Existing failsafe tests updated to the new wiring.
- `bin/rails test test/initializers/` → 18 runs, 43 assertions, 0 failures.
- Manually verified in a real dev boot: corrupted the cache file → boot healed it (`quick_check: "ok"`, schema recreated, cache readable/writable) before any traffic; verified the handler is installed on the live store and that recovery also works at runtime.

## Ops note

The underlying corruption *driver* — one storage volume shared by web/jobs/blaze for ActiveStorage — remains. This makes the app resilient to it; if corruption recurs frequently, giving Solid Cache its own web-only path is the structural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)