### PR TITLE
fix: forward html_options through render_button/render_chip; drop doubled %% in list rows

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -30,11 +30,11 @@ module UiHelper
   # See specs/011-comprehensive-ui-refactor/contracts/primitives.md.
 
   def render_button(label, variant: :primary, size: :md, icon: nil, href: nil, type: "button", **html_options)
-    render "shared/button", label:, variant:, size:, icon:, href:, type:, **html_options
+    render "shared/button", label:, variant:, size:, icon:, href:, type:, html_options:
   end
 
   def render_chip(label, kind: :topic, **html_options)
-    render "shared/chip", label:, kind:, **html_options
+    render "shared/chip", label:, kind:, html_options:
   end
 
   def render_list_row(article, **opts)

--- a/app/views/design_system/_dropdown.html.erb
+++ b/app/views/design_system/_dropdown.html.erb
@@ -2,7 +2,7 @@
 <%= render_dropdown(
       class: "ds-dropdown-example",
       button: render_button("Options", variant: :soft, icon: "dots-vertical",
-                            html_options: { data: { action: "click->flyonui-dropdown#toggle" } })
+                            data: { action: "click->flyonui-dropdown#toggle" })
     ) do %>
   <%= link_to "Edit",     "#", class: "block px-4 py-2 text-sm hover:bg-base-200" %>
   <%= link_to "Duplicate", "#", class: "block px-4 py-2 text-sm hover:bg-base-200" %>

--- a/app/views/shared/_list_row.html.erb
+++ b/app/views/shared/_list_row.html.erb
@@ -30,7 +30,7 @@
           <span class="font-mono"><%= article.created_at&.strftime("%b %-d") %></span>
         <% end %>
         <% if article.respond_to?(:early_reader_reward_ratio) && article.early_reader_reward_ratio.to_f > 0 %>
-          <%= render_value_note("+#{article.early_reader_reward_ratio.to_i}%", label: "early reader", format: :percent) %>
+          <%= render_value_note("+#{article.early_reader_reward_ratio.to_i}", label: "early reader", format: :percent) %>
         <% end %>
       </div>
     <% end %>

--- a/test/helpers/ui_helper_test.rb
+++ b/test/helpers/ui_helper_test.rb
@@ -164,9 +164,12 @@ class UiHelperTest < ActionView::TestCase
   end
 
   test "render_value_note is text-only and never emits a filled badge background" do
-    html = render_value_note("+40%", label: "early reader", format: :percent)
+    html = render_value_note("+40", label: "early reader", format: :percent)
 
-    assert_includes html, "text-reward"
+    # reward-text is the specced utility (specs/011 T009) composing
+    # font-mono text-[13px] text-reward.
+    assert_includes html, "reward-text"
+    assert_includes html, "+40%"
     assert_not_includes html, "rounded-full"
     assert_not_includes html, "bg-base-content"
   end


### PR DESCRIPTION
## Summary

Fixes three tests that have been failing on main since #2040 merged, plus a rendering bug the failing test output exposed.

**Root cause** — the design-system primitives split behavior between helper and partial, and the two halves disagree:

- `UiHelper#render_button` / `render_chip` collect `**html_options` and splat them as top-level render locals.
- `_button.html.erb` / `_chip.html.erb` read `local_assigns.fetch(:html_options, {})`.

Result: every forwarded `class:` / `data:` attribute was silently dropped.

## Changes

- `ui_helper.rb`: pass `html_options` as a single local, matching the partials and the `primitives.md` contract ("**html_options — forwarded to the rendered element").
- `design_system/_dropdown.html.erb`: the showcase passed `html_options: { data: ... }` as a named kwarg (working by accident of the old wiring); pass `data:` directly as the contract documents.
- `shared/_list_row.html.erb`: the early-reader note passed a value already ending in `%` plus `format: :percent`, rendering `+40%%` on every feed row. Pass the raw number.
- `ui_helper_test.rb`: assert the specced `reward-text` utility (011 T009) instead of the literal `text-reward` token, and assert the `+40%` output.

## Test Status

- Full suite locally: **1398 runs, 0 failures, 0 errors, 3 skips** (3 skips pre-existing).
- Before this branch: 1398 runs, 3 failures (button/chip forwarding + value_note styling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)