### PR TITLE
fix: space stacked sections with flex gap instead of space-y

### DIFF
--- a/app/views/articles/_widgets.html.erb
+++ b/app/views/articles/_widgets.html.erb
@@ -2,7 +2,7 @@
     in the single-column public layout — author card, collection, references,
     related articles, and hot tags render inline below the article body
     instead, spaced like the home feed's inline widget strip. %>
-<div class="space-y-10">
+<div class="flex flex-col gap-10">
   <%= render "users/user_card", user: article.author %>
   <%= render "collections/card", collection: article.collection if article.collection.present? %>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -9,7 +9,7 @@
 <%# The old right-rail sidebar (active authors, hot tags, footer) has no
     persistent widget rail in the new single-column public layout (design
     doc §5.2) — these move inline, below the feed, as a compact strip. %>
-<div class="mt-12 space-y-10 border-t border-base-300 pt-8">
+<div class="mt-12 flex flex-col gap-10 border-t border-base-300 pt-8">
   <% if @tag.present? %>
     <%= turbo_frame_tag 'selected_tag' do %>
       <%= render "tags/tag_card", tag: @tag %>

--- a/app/views/dashboard/home/account.html.erb
+++ b/app/views/dashboard/home/account.html.erb
@@ -2,7 +2,7 @@
     predictable place (specs/005-dashboard-ux-redesign, US7), closing the
     access-tokens discoverability gap (FR-003/FR-025). Every sub-area reuses
     its existing controller unchanged. %>
-<div class="space-y-10">
+<div class="flex flex-col gap-10">
   <h1 class="font-display text-2xl font-medium text-base-content"><%= t('account') %></h1>
 
   <section id="account-profile">

--- a/app/views/dashboard/home/finances.html.erb
+++ b/app/views/dashboard/home/finances.html.erb
@@ -5,7 +5,7 @@
     Dashboard::PaymentsController/TransfersController unchanged; the
     Write/Read workspaces' role-scoped transfer embeds (tab: :author / :reader)
     remain shortcuts into this same underlying data. %>
-<div class="space-y-10">
+<div class="flex flex-col gap-10">
   <h1 class="font-display text-2xl font-medium text-base-content"><%= t('finances') %></h1>
 
   <section id="finances-spending">

--- a/app/views/dashboard/home/read.html.erb
+++ b/app/views/dashboard/home/read.html.erb
@@ -4,7 +4,7 @@
     page keeps only reading-native sub-areas plus a reader-earnings shortcut
     (FR-016–FR-018). Every section reuses its existing controller/turbo-frame
     endpoint unchanged. %>
-<div class="space-y-10">
+<div class="flex flex-col gap-10">
   <h1 class="font-display text-2xl font-medium text-base-content"><%= t('read') %></h1>
 
   <section id="read-bought">

--- a/app/views/dashboard/home/write.html.erb
+++ b/app/views/dashboard/home/write.html.erb
@@ -3,7 +3,7 @@
     existing controller/turbo-frame endpoint unchanged (FR-012–FR-015); only
     the presentation groups them together instead of hiding all but one
     behind a tab switch. %>
-<div class="space-y-10">
+<div class="flex flex-col gap-10">
   <div class="flex items-center justify-between">
     <h1 class="font-display text-2xl font-medium text-base-content"><%= t('write') %></h1>
     <%= link_to new_article_path, class: "btn btn-primary btn-sm rounded-full" do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -59,7 +59,7 @@
   <% end %>
 </section>
 
-<div class="space-y-10 border-t border-base-300 pt-8">
+<div class="flex flex-col gap-10 border-t border-base-300 pt-8">
   <%= turbo_frame_tag 'active_authors', src: active_authors_path, loading: :lazy %>
   <%= turbo_frame_tag 'hot_tags', src: hot_tags_path, loading: :lazy %>
   <%= render 'shared/footer' %>


### PR DESCRIPTION
## Summary
- `#2047` flattened Tailwind `space-y-*` in production, but home/articles stacks still looked tight: the rule applies `margin-block` to children, and `<turbo-frame>` is `display: inline`, so those margins do not affect layout.
- Inspecting the parent also showed no `space-y-10` rule, because the flattened selector targets children, not the wrapper.
- Replace those seven `space-y-10` stacks with `flex flex-col gap-10` so 2.5rem spacing lives on the parent and works regardless of child display. No global `turbo-frame` style change.

## Test plan
- [ ] After deploy, open https://quill.im/ and confirm ~40px gaps between Active Authors, Hot Tags, and the footer
- [ ] Inspect the wrapper: Styles should show `display: flex`, `flex-direction: column`, `gap: 2.5rem`
- [ ] Check `/articles` widget strip and an article's bottom widgets
- [ ] Spot-check dashboard Write / Read / Finances / Account section spacing
- [ ] Confirm modal frames and other turbo-frames still layout as before (no global frame display change)


Made with [Cursor](https://cursor.com)