### PR TITLE
fix: raise RecordNotFound when API articles author_id is unknown

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -9,7 +9,7 @@ class API::ArticlesController < API::BaseController
     @articles =
       if params[:author_id].present?
         author = User.find_by(mixin_uuid: params[:author_id])
-        raise ActiveRecord::RecordNotFound && return if author.blank?
+        raise ActiveRecord::RecordNotFound if author.blank?
 
         author.articles.only_published
       elsif current_user

--- a/test/controllers/api/articles_controller_test.rb
+++ b/test/controllers/api/articles_controller_test.rb
@@ -36,6 +36,24 @@ class API::ArticlesControllerTest < IntegrationTestCase
     assert_equal article.content_body, response.parsed_body["content"]
   end
 
+  test "index returns 404 when author_id does not match a user" do
+    get api_articles_path(author_id: "00000000-0000-4000-8000-000000000000"), as: :json
+
+    assert_response :not_found
+    assert_equal "Not found", response.parsed_body["message"]
+  end
+
+  test "index returns published articles for a known author_id" do
+    author = users(:author)
+
+    get api_articles_path(author_id: author.mixin_uuid), as: :json
+
+    assert_response :success
+    uuids = response.parsed_body.pluck("uuid")
+    assert_includes uuids, articles(:published_paid).uuid
+    assert_not_includes uuids, articles(:draft).uuid
+  end
+
   test "index truncates an oversized query param to the length limit" do
     limit = API::ArticlesController::QUERY_LENGTH_LIMIT
     long_query = "a" * (limit + 50)


### PR DESCRIPTION
## Summary
- `API::ArticlesController#index` used `raise ActiveRecord::RecordNotFound && return`. Operator precedence builds `raise(X && return)`, so `return` exits the action and `raise` never runs.
- Confirmed locally: the expression returns `nil` rather than raising. `GET /api/articles?author_id=<unknown>` then rendered with `@articles = nil` and a 200 instead of the documented 404.
- Drop the `&& return` so the existing `rescue_from ActiveRecord::RecordNotFound` in `API::BaseController` renders `{ "message": "Not found" }` with status 404.
- Adds a regression test for an unknown UUID and a happy-path assertion that a known `author_id` still lists that author's published articles (drafts excluded).

Closes #2052

## Test plan
- [x] Reproduced the no-op raise in `bin/rails runner` (`returned: nil`)
- [x] `bin/rails test test/controllers/api/articles_controller_test.rb`
- [x] `bin/rubocop app/controllers/api/articles_controller.rb test/controllers/api/articles_controller_test.rb`
- [ ] CI Check on this PR


Made with [Cursor](https://cursor.com)