### PR TITLE
ci: cancel in-progress Check runs on the same ref

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,6 +36,10 @@ on:
       - main
     paths: *check_paths
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Check:
     runs-on: [self-hosted, linux]


### PR DESCRIPTION
## Summary
- The Check workflow had no `concurrency` group, so every push (and merge-queue refresh) started a full `bundle install` + `bun install` + Rails + lint run alongside the previous one on the self-hosted runner.
- Add a per-ref group with `cancel-in-progress: true` so a newer commit on the same branch supersedes the in-flight Check.
- Group is `${{ github.workflow }}-${{ github.ref }}`, so `main` and feature branches do not cancel each other.

Closes #2053

## Test plan
- [x] `ruby -ryaml -e 'YAML.load_file(\".github/workflows/check.yml\", aliases: true)'` parses (handles the existing `*check_paths` anchor)
- [ ] Confirm a second push to this branch cancels the previous Check run
- [ ] Confirm a Check on `main` is not cancelled by this PR


Made with [Cursor](https://cursor.com)