### PR TITLE
fix: stop notifying followers who blocked the buyer

### DIFF
--- a/app/notifiers/article_bought_notifier.rb
+++ b/app/notifiers/article_bought_notifier.rb
@@ -48,8 +48,16 @@ class ArticleBoughtNotifier < ApplicationNotifier
       recipient.notification_setting.article_bought_mixin_bot
     end
 
+    def should_notify?
+      !recipient.block_user? order.buyer
+    end
+
+    def may_notify_via_web?
+      should_notify? && web_notification_enabled?
+    end
+
     def may_notify_via_mixin_bot?
-      recipient_messenger? && mixin_bot_notification_enabled?
+      should_notify? && recipient_messenger? && mixin_bot_notification_enabled?
     end
   end
 end

--- a/app/notifiers/article_rewarded_notifier.rb
+++ b/app/notifiers/article_rewarded_notifier.rb
@@ -48,8 +48,16 @@ class ArticleRewardedNotifier < ApplicationNotifier
       recipient.notification_setting.article_rewarded_mixin_bot
     end
 
+    def should_notify?
+      !recipient.block_user? order.buyer
+    end
+
+    def may_notify_via_web?
+      should_notify? && web_notification_enabled?
+    end
+
     def may_notify_via_mixin_bot?
-      recipient_messenger? && mixin_bot_notification_enabled?
+      should_notify? && recipient_messenger? && mixin_bot_notification_enabled?
     end
   end
 end

--- a/app/notifiers/collection_bought_notifier.rb
+++ b/app/notifiers/collection_bought_notifier.rb
@@ -50,8 +50,16 @@ class CollectionBoughtNotifier < ApplicationNotifier
       recipient.notification_setting.article_bought_mixin_bot
     end
 
+    def should_notify?
+      !recipient.block_user? order.buyer
+    end
+
+    def may_notify_via_web?
+      should_notify? && web_notification_enabled?
+    end
+
     def may_notify_via_mixin_bot?
-      recipient_messenger? && mixin_bot_notification_enabled?
+      should_notify? && recipient_messenger? && mixin_bot_notification_enabled?
     end
   end
 end

--- a/test/TESTING_GUIDE.md
+++ b/test/TESTING_GUIDE.md
@@ -170,6 +170,7 @@ Some tests change methods on a model or notifier class with `define_method` and 
 
 ### Order
 - `setup_attributes` requires a real `Payment.amount`. Bypass with `save(validate: false)`.
+- `notify_subscribers` delivers to the buyer's followers. `ArticleBoughtNotifier` / `ArticleRewardedNotifier` / `CollectionBoughtNotifier` guard with `should_notify? → !recipient.block_user?(order.buyer)`: a follower who blocked the buyer still gets the persisted row but `visible_in_web?` is false and mixin delivery is skipped.
 
 ### Splitter
 - `collect_assets` wraps in `with_advisory_lock("splitter:#{id}:collect")`. Short-circuits when lock is not acquired.

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -636,6 +636,27 @@ class OrderTest < ActiveSupport::TestCase
     end
   end
 
+  # `ArticleBoughtNotifier#should_notify?` folds the recipient-side block
+  # guard into both delivery paths (`may_notify_via_web?` and the mixin bot
+  # `config.if`). The Noticed row still persists — the web inbox and the
+  # Mixin bot just have to stop showing/sending it.
+  test "notify_subscribers does not deliver to followers who blocked the buyer" do
+    with_quill_bot_stub do
+      ensure_notification_setting!(@reader_one)
+      ensure_notification_setting!(@reader_two)
+
+      @reader_two.create_action(:subscribe, target: @reader_one) unless @reader_two.subscribe_user?(@reader_one)
+      @reader_two.create_action(:block, target: @reader_one)
+
+      order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+      order.notify_subscribers
+
+      notification = Noticed::Notification.where(recipient: @reader_two).order(:id).last
+      assert notification, "Noticed persists the row before delivery gating"
+      assert_not notification.visible_in_web?
+    end
+  end
+
   private
 
   # Captures every SQL query emitted while running `block`, dropping the

--- a/test/notifiers/article_bought_notifier_test.rb
+++ b/test/notifiers/article_bought_notifier_test.rb
@@ -37,6 +37,16 @@ class ArticleBoughtNotifierTest < ActiveSupport::TestCase
     assert_not notification_for(@author).visible_in_web?
   end
 
+  test "visible_in_web is false when recipient blocked the buyer" do
+    @author.create_action(:block, target: @buyer)
+
+    deliver_notifier!(ArticleBoughtNotifier, record: @order, order: @order, recipient: @author)
+
+    notification = notification_for(@author)
+    assert_not notification.visible_in_web?
+    assert_not notification.may_notify_via_mixin_bot?
+  end
+
   test "deliver enqueues mixin bot delivery for messenger recipients" do
     deliver_notifier!(ArticleBoughtNotifier, record: @order, order: @order, recipient: @author)
 

--- a/test/notifiers/article_rewarded_notifier_test.rb
+++ b/test/notifiers/article_rewarded_notifier_test.rb
@@ -66,6 +66,16 @@ class ArticleRewardedNotifierTest < ActiveSupport::TestCase
     assert_not notification_for(@author).visible_in_web?
   end
 
+  test "visible_in_web is false when recipient blocked the buyer" do
+    @author.create_action(:block, target: @buyer)
+
+    deliver_notifier!(ArticleRewardedNotifier, record: @order, order: @order, recipient: @author)
+
+    notification = notification_for(@author)
+    assert_not notification.visible_in_web?
+    assert_not notification.may_notify_via_mixin_bot?
+  end
+
   test "deliver enqueues mixin bot delivery for messenger recipients" do
     assert @author.messenger?
 

--- a/test/notifiers/collection_bought_notifier_test.rb
+++ b/test/notifiers/collection_bought_notifier_test.rb
@@ -160,6 +160,21 @@ class CollectionBoughtNotifierTest < ActiveSupport::TestCase
     assert_not notification_for(@subscriber).visible_in_web?
   end
 
+  test "visible_in_web is false when subscriber blocked the buyer" do
+    @subscriber.create_action(:block, target: @buyer)
+
+    deliver_notifier!(
+      CollectionBoughtNotifier,
+      record: @order,
+      order: @order,
+      recipient: @subscriber
+    )
+
+    notification = notification_for(@subscriber)
+    assert_not notification.visible_in_web?
+    assert_not notification.may_notify_via_mixin_bot?
+  end
+
   test "deliver enqueues mixin bot delivery for messenger recipients" do
     assert @subscriber.messenger?
 


### PR DESCRIPTION
Closes #2066

## Problem

`Order#notify_subscribers` delivers buy / reward / collection-bought notifications to the buyer's followers with no block guard. `ArticleBoughtNotifier`, `ArticleRewardedNotifier`, and `CollectionBoughtNotifier` had no `should_notify?` — unlike `CommentCreatedNotifier` (`app/notifiers/comment_created_notifier.rb:43-45`) and `TaggingCreatedNotifier` — so a follower who had blocked the buyer still received "X bought Y" both in the web inbox and via the Mixin bot.

## Fix

Mirror the comment/tagging convention. Each of the three order-path notifiers now defines:

````ruby
def should_notify?
  !recipient.block_user? order.buyer
end
````

and folds it into both delivery gates:

- `may_notify_via_web?` → the inbox (`visible_in_web?` duck-types it in `config/initializers/noticed.rb`)
- `may_notify_via_mixin_bot?` → the `deliver_by :mixin_bot config.if`

Per the Noticed-3 convention the `Noticed::Notification` row still persists — it just stops being web-visible and stops enqueueing a Mixin bot message.

## Tests

- Per-notifier: `visible_in_web is false when recipient blocked the buyer` for all three (also asserts `may_notify_via_mixin_bot?` false)
- End-to-end: `notify_subscribers does not deliver to followers who blocked the buyer` in `test/models/order_test.rb`
- Targeted run: 3 notifier suites + order suite → **52 runs, 147 assertions, 0 failures**; `bin/rubocop` clean on changed files
- `test/TESTING_GUIDE.md` updated with the guard semantics

## Note

The emitter-side direction (excluding users the *buyer* has blocked, as `Article#notify_subscribers` does for authors via `blocked_user_ids_relation`) is a separate consistency question — left to the audience-resolution refactor (#2073) rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
