### PR TITLE
refactor: one transfer-issuing verb in the value net

### DIFF
--- a/app/services/orders/distribute_service.rb
+++ b/app/services/orders/distribute_service.rb
@@ -45,35 +45,24 @@ class Orders::DistributeService
 
   def distribute_collection_order!
     if payment.wallet_id != QuillBot.api.client_id
-      transfers.create_with(
-        queue_priority: :low,
-        wallet_id: payment.wallet_id,
+      issue_revenue_transfer!(
         transfer_type: :quill_revenue,
-        opponent_id: QuillBot.api.client_id,
-        asset_id: revenue_asset_id,
+        to: QuillBot.api.client_id,
         amount: quill_amount.to_s,
-        memo: Base64.encode64({
-          t: "REVENUE",
-          a: item.uuid
-        }.to_json)
-      ).find_or_create_by!(
-        trace_id: MixinBot::Utils.unique_uuid(trace_id, QuillBot.api.client_id)
+        memo: quill_revenue_memo,
+        trace_id: MixinBot::Utils.unique_uuid(trace_id, QuillBot.api.client_id),
+        wallet_id: payment.wallet_id
       )
     end
 
-    author_revenue_transfer_memo = "#{buyer.name} bought #{item.name}"
     author_mixin_uuid = item.author.mixin_uuid
-
-    transfers.create_with(
-      queue_priority: :low,
-      wallet_id: payment.wallet_id,
+    issue_revenue_transfer!(
       transfer_type: :author_revenue,
-      opponent_id: author_mixin_uuid,
-      asset_id: revenue_asset_id,
+      to: author_mixin_uuid,
       amount: (total - quill_amount).floor(8),
-      memo: author_revenue_transfer_memo.truncate(70)
-    ).find_or_create_by!(
-      trace_id: MixinBot::Utils.unique_uuid(trace_id, author_mixin_uuid)
+      memo: "#{buyer.name} bought #{item.name}".truncate(70),
+      trace_id: MixinBot::Utils.unique_uuid(trace_id, author_mixin_uuid),
+      wallet_id: payment.wallet_id
     )
   end
 
@@ -83,18 +72,11 @@ class Orders::DistributeService
     readers_share_column = early_orders_with_the_same_currency ? :total : :value_btc
 
     if quill_amount.positive? && payment.wallet_id != QuillBot.api.client_id
-      transfers.create_with(
-        queue_priority: :low,
-        wallet_id: distributor_wallet_id,
+      issue_revenue_transfer!(
         transfer_type: :quill_revenue,
-        opponent_id: QuillBot.api.client_id,
-        asset_id: revenue_asset_id,
+        to: QuillBot.api.client_id,
         amount: quill_amount.to_s,
-        memo: Base64.encode64({
-          t: "REVENUE",
-          a: item.uuid
-        }.to_json)
-      ).find_or_create_by!(
+        memo: quill_revenue_memo,
         trace_id: MixinBot::Utils.unique_uuid(trace_id, QuillBot.api.client_id)
       )
     end
@@ -123,15 +105,11 @@ class Orders::DistributeService
 
       order_ids = early_readers_by_mixin_uuid.fetch(reader_id)
       salt = order_ids.push trace_id
-      transfers.create_with(
-        queue_priority: :low,
-        wallet_id: distributor_wallet_id,
+      issue_revenue_transfer!(
         transfer_type: :reader_revenue,
-        opponent_id: reader_id,
-        asset_id: revenue_asset_id,
+        to: reader_id,
         amount: _amount.to_f.to_s,
-        memo: "Reader revenue from #{item.title}".truncate(70)
-      ).find_or_create_by!(
+        memo: "Reader revenue from #{item.title}".truncate(70),
         trace_id: MixinBot::Utils.unique_uuid(*salt)
       )
 
@@ -142,30 +120,19 @@ class Orders::DistributeService
     # Eager-load each ArticleReference's referenced Article and its author in
     # a fixed 3 queries (article_references + references + authors) instead of
     # the prior `2R + 1` pattern (count + N article_references + N authors).
-    references = item.article_references.includes(reference: :author)
-    if references.any?
-      references.each do |ref|
-        _ref_amount = (total * ref.revenue_ratio).floor(8)
-        next if (_ref_amount - MINIMUM_AMOUNT).negative?
+    item.article_references.includes(reference: :author).each do |ref|
+      _ref_amount = (total * ref.revenue_ratio).floor(8)
+      next if (_ref_amount - MINIMUM_AMOUNT).negative?
 
-        transfers.create_with(
-          queue_priority: :low,
-          transfer_type: :reference_revenue,
-          wallet_id: distributor_wallet_id,
-          opponent_id: ref.reference.author.mixin_uuid,
-          asset_id: revenue_asset_id,
-          amount: _ref_amount,
-          memo: Base64.encode64({
-            t: "CITE",
-            a: ref.reference.uuid,
-            c: item.uuid
-          }.to_json)
-        ).find_or_create_by(
-          trace_id: QuillBot.api.unique_uuid(trace_id, ref.reference.uuid)
-        )
+      issue_revenue_transfer!(
+        transfer_type: :reference_revenue,
+        to: ref.reference.author.mixin_uuid,
+        amount: _ref_amount,
+        memo: Base64.encode64({ t: "CITE", a: ref.reference.uuid, c: item.uuid }.to_json),
+        trace_id: QuillBot.api.unique_uuid(trace_id, ref.reference.uuid)
+      )
 
-        _references_amount += _ref_amount
-      end
+      _references_amount += _ref_amount
     end
 
     _collection_amount = 0.0
@@ -192,15 +159,11 @@ class Orders::DistributeService
 
     if (_collection_avg_amount - MINIMUM_AMOUNT).positive?
       collection.orders.includes(:buyer).where(order_type: :buy_collection).find_each do |_order|
-        transfers.create_with(
-          queue_priority: :low,
-          wallet_id: distributor_wallet_id,
+        issue_revenue_transfer!(
           transfer_type: :reader_revenue,
-          opponent_id: _order.buyer.mixin_uuid,
-          asset_id: revenue_asset_id,
+          to: _order.buyer.mixin_uuid,
           amount: _collection_avg_amount,
-          memo: "collection revenue from #{item.title}".truncate(70)
-        ).find_or_create_by!(
+          memo: "collection revenue from #{item.title}".truncate(70),
           trace_id: QuillBot.api.unique_uuid(trace_id, _order.trace_id)
         )
         _collection_amount += _collection_avg_amount
@@ -217,17 +180,34 @@ class Orders::DistributeService
         "#{buyer.name} #{buy_article? ? 'bought' : 'rewarded'} #{item.title}"
       end
     author_mixin_uuid = item.author.mixin_uuid
-    transfers.create_with(
-      queue_priority: :low,
-      wallet_id: distributor_wallet_id,
+    issue_revenue_transfer!(
       transfer_type: :author_revenue,
-      opponent_id: author_mixin_uuid,
-      asset_id: revenue_asset_id,
+      to: author_mixin_uuid,
       amount: author_revenue_amount,
-      memo: author_revenue_transfer_memo.truncate(70)
-    ).find_or_create_by!(
+      memo: author_revenue_transfer_memo.truncate(70),
       trace_id: QuillBot.api.unique_uuid(trace_id, author_mixin_uuid)
     )
+  end
+
+  # The single mechanics for every revenue transfer the value net emits:
+  # low queue priority, payment-asset denomination, and idempotency keyed
+  # on the caller-derived trace_id. Call sites own the policy — transfer
+  # type, opponent, amount, memo text, trace derivation and funding wallet —
+  # so each payout reads as a statement of who gets what.
+  def issue_revenue_transfer!(transfer_type:, to:, amount:, memo:, trace_id:, wallet_id: distributor_wallet_id)
+    transfers.create_with(
+      queue_priority: :low,
+      wallet_id: wallet_id,
+      transfer_type: transfer_type,
+      opponent_id: to,
+      asset_id: revenue_asset_id,
+      amount: amount,
+      memo: memo
+    ).find_or_create_by!(trace_id: trace_id)
+  end
+
+  def quill_revenue_memo
+    Base64.encode64({ t: "REVENUE", a: item.uuid }.to_json)
   end
 
   def quill_amount


### PR DESCRIPTION
Closes #2069

## What changed

`Orders::DistributeService` had no "issue a Transfer" operation: seven near-identical blocks (38% of the file) each repeated the full `transfers.create_with(queue_priority:, wallet_id:, transfer_type:, opponent_id:, asset_id:, amount:, memo: …).find_or_create_by!(trace_id: …)` idiom, fusing payout policy with payout mechanics. `distribute_collection_order!` was ~85% duplicate of its article sibling.

The seven blocks now call one private verb:

```ruby
issue_revenue_transfer!(transfer_type:, to:, amount:, memo:, trace_id:, wallet_id: distributor_wallet_id)
```

which owns the mechanics — low queue priority, payment-asset denomination (`revenue_asset_id`), and idempotency keyed on `trace_id` via `find_or_create_by!`. Each call site is now 3–6 lines of pure policy: type, opponent, amount, memo text, trace derivation, funding wallet.

## Deliberately preserved (out of scope here)

- **The two idempotency-key derivations stay per call site** — `MixinBot::Utils.unique_uuid` (collection quill/author, article quill, early-reader salt) vs `QuillBot.api.unique_uuid` (reference, collection-revenue, article author). Unifying them is #2071 (memo & trace adapter); doing it here would risk silently changing derived keys against persisted rows.
- **The funding-wallet split stays** — collection path passes `wallet_id: payment.wallet_id`, article path uses the `distributor_wallet_id` default. That divergence is #2070's seam; after this refactor it is now visible as a one-line difference between two call sites.
- **Memo text and `.truncate(70)` stay at call sites.** The Base64 memos must not be truncated (truncation would corrupt the JSON), so a uniform cap inside the verb would be wrong. Memo encoding unification is #2071.

## Two small behaviour notes

- The reference-revenue block used non-bang `find_or_create_by` — the other six used `!`. On a validation failure the non-bang variant silently drops the transfer **while still subtracting the amount from author revenue** (money vanishes from the ledger). All seven now go through the strict verb; the existing reference tests pass unchanged.
- Dropped the `if references.any?` guard — `.each` on an empty loaded relation is a no-op, so the guard was one extra query.

## Not touched

The perf shapes are intact: the single grouped SUM (`share_by_trace_id`) and the hoisted `collect_early_readers` remain, and both white-box tests (`exactly 1 SUM query`, `collect_early_readers invoked exactly once`) pass unmodified. File goes 244 → 232 LOC, but the win is concentration: the nine-argument create_with mechanics now exist exactly once, and a new revenue stream is one verb call.

## Tests

`test/services/orders/*` + `test/models/concerns/orders/*` + `order_test` → 69 runs, 157 assertions, 0 failures (all memo/trace/priority/wallet/idempotency assertions unchanged from main). Full suite: 1424 runs, 0 failures, 3 pre-existing skips. `bin/rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
