### PR TITLE
fix: funding-wallet seam and a real completion guard

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -104,16 +104,19 @@ class Order < ApplicationRecord
     end
   end
 
+  # The ledger invariant, in one place: the revenue transfers that debit the
+  # funding wallet (`payment.wallet_id`) must sum to the full total — minus
+  # the platform's own share when the platform wallet funded the payment,
+  # since its fee never transfers to itself.
   def all_transfers_generated?
-    transfers
-      .where(wallet_id: payment.wallet_id)
-      .sum(:amount)
-      .round(8) >=
-      if payment.wallet_id == QuillBot.api.client_id
+    expected =
+      if payment.platform_wallet?
         (total * (1 - item.platform_revenue_ratio)).round(8)
       else
         total.round(8)
       end
+
+    transfers.where(wallet_id: payment.wallet_id).sum(:amount).round(8) >= expected
   end
 
   def notify

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -227,6 +227,14 @@ class Payment < ApplicationRecord
     @wallet_id = snapshot&.user_id
   end
 
+  # Whether the payment landed in the platform bot's wallet. When it did,
+  # the bot fronts every revenue payout from its own holdings and keeps its
+  # fee in place (no quill_revenue transfer is emitted), so the ledger
+  # expectation in `Order#all_transfers_generated?` differs.
+  def platform_wallet?
+    wallet_id == QuillBot.api.client_id
+  end
+
   def ensure_refund_transfer_created
     refund_transfer.present?
   end

--- a/app/services/orders/distribute_service.rb
+++ b/app/services/orders/distribute_service.rb
@@ -44,7 +44,7 @@ class Orders::DistributeService
            to: :order
 
   def distribute_collection_order!
-    if payment.wallet_id != QuillBot.api.client_id
+    unless payment.platform_wallet?
       issue_revenue_transfer!(
         transfer_type: :quill_revenue,
         to: QuillBot.api.client_id,
@@ -71,7 +71,7 @@ class Orders::DistributeService
 
     readers_share_column = early_orders_with_the_same_currency ? :total : :value_btc
 
-    if quill_amount.positive? && payment.wallet_id != QuillBot.api.client_id
+    if quill_amount.positive? && !payment.platform_wallet?
       issue_revenue_transfer!(
         transfer_type: :quill_revenue,
         to: QuillBot.api.client_id,
@@ -191,10 +191,11 @@ class Orders::DistributeService
 
   # The single mechanics for every revenue transfer the value net emits:
   # low queue priority, payment-asset denomination, and idempotency keyed
-  # on the caller-derived trace_id. Call sites own the policy — transfer
-  # type, opponent, amount, memo text, trace derivation and funding wallet —
-  # so each payout reads as a statement of who gets what.
-  def issue_revenue_transfer!(transfer_type:, to:, amount:, memo:, trace_id:, wallet_id: distributor_wallet_id)
+  # on the caller-derived trace_id. Every payout debits the wallet that
+  # funded the payment. Call sites own the policy — transfer type,
+  # opponent, amount, memo text and trace derivation — so each payout
+  # reads as a statement of who gets what.
+  def issue_revenue_transfer!(transfer_type:, to:, amount:, memo:, trace_id:, wallet_id: payment.wallet_id)
     transfers.create_with(
       queue_priority: :low,
       wallet_id: wallet_id,
@@ -212,10 +213,6 @@ class Orders::DistributeService
 
   def quill_amount
     @quill_amount ||= (total * item.platform_revenue_ratio).floor(8)
-  end
-
-  def distributor_wallet_id
-    @distributor_wallet_id ||= QuillBot.api.client_id
   end
 
   def revenue_asset_id

--- a/config/initializers/solid_cache_failsafe.rb
+++ b/config/initializers/solid_cache_failsafe.rb
@@ -66,7 +66,7 @@ module SolidCacheRecovery
   # SQLITE_CORRUPT ("database disk image is malformed") and SQLITE_NOTADB
   # ("file is not a database" — zeroed-out or truncated file) both mean the
   # file itself is unusable, as opposed to transient lock/timeout errors.
-  RECOVERABLE_SQLITE_ERRORS = [SQLite3::CorruptException, SQLite3::NotADatabaseException].freeze
+  RECOVERABLE_SQLITE_ERRORS = [ SQLite3::CorruptException, SQLite3::NotADatabaseException ].freeze
 
   # Installed as the Solid Cache store's `error_handler` at the bottom of this
   # file. Solid Cache routes every error it handles itself through this one
@@ -141,7 +141,7 @@ module SolidCacheRecovery
       end
 
       def remove_database_files!
-        [db_path, "#{db_path}-wal", "#{db_path}-shm", "#{db_path}-journal"].each do |file|
+        [ db_path, "#{db_path}-wal", "#{db_path}-shm", "#{db_path}-journal" ].each do |file|
           File.delete(file) if File.exist?(file)
         end
       end

--- a/docs/explanation/value-net.md
+++ b/docs/explanation/value-net.md
@@ -44,7 +44,7 @@ Per-article and per-user Mixin wallets are no longer created — provisioning co
 | **Reference revenue** | `reference.author.mixin_uuid` (cited article's author) |
 | **Collection revenue** | `_order.buyer.mixin_uuid` |
 
-For article-order transfers the **source** (`transfers.wallet_id`) is the platform bot (`Orders::DistributeService#distributor_wallet_id = QuillBot.api.client_id`); for collection orders the source is `payment.wallet_id` (the buyer's Mixin identity).
+Revenue transfers always debit the wallet that funded the payment (`transfers.wallet_id = payment.wallet_id`): the platform bot when the payment landed there — in which case its own fee stays in place and no `quill_revenue` transfer is emitted — otherwise the external wallet that received the payment. `Order#all_transfers_generated?` states the matching ledger invariant.
 
 ## Further reading
 

--- a/test/helpers/ui_helper_test.rb
+++ b/test/helpers/ui_helper_test.rb
@@ -48,7 +48,7 @@ class UiHelperTest < ActionView::TestCase
   test "render_button renders an icon span when icon is provided" do
     html = render_button("Lock", icon: "lock-open")
 
-    assert_includes html, 'i-[tabler--lock-open]'
+    assert_includes html, "i-[tabler--lock-open]"
     assert_includes html, "Lock"
   end
 

--- a/test/initializers/solid_cache_recovery_test.rb
+++ b/test/initializers/solid_cache_recovery_test.rb
@@ -16,7 +16,7 @@ require "test_helper"
 # pointed at a scratch database instead of `SolidCache::Record` so the tests
 # never touch the real cache/primary pools.
 class SolidCacheRecoveryTest < ActiveSupport::TestCase
-  SIDE_CAR_SUFFIXES = ["", "-wal", "-shm", "-journal"].freeze
+  SIDE_CAR_SUFFIXES = [ "", "-wal", "-shm", "-journal" ].freeze
 
   setup do
     # Unique per test so `establish_connection` always builds a fresh pool

--- a/test/jobs/orders/distribute_job_test.rb
+++ b/test/jobs/orders/distribute_job_test.rb
@@ -7,11 +7,10 @@ class Orders::DistributeJobTest < JobTestCase
     with_quill_bot_stub do
       order = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_one), total: 1.0)
 
-      with_all_transfers_generated! do
-        Orders::DistributeJob.perform_now(order.trace_id)
-      end
+      Orders::DistributeJob.perform_now(order.trace_id)
 
       assert order.transfers.exists?
+      assert order.reload.completed?, "the job should leave the order completed through the real guard"
     end
   end
 

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -97,9 +97,13 @@ class OrderTest < ActiveSupport::TestCase
     end
   end
 
-  test "all_transfers_generated? when transfers sum to expected amount" do
+  # `distribute_order!` runs the real service and the real guard — this is
+  # the ledger invariant itself, not a stubbed predicate.
+  test "all_transfers_generated? is false before distribution and true after a real one" do
     with_quill_bot_stub do
       order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+      assert_not order.all_transfers_generated?
+
       distribute_order!(order)
 
       assert order.all_transfers_generated?

--- a/test/services/orders/distribute_service_article_test.rb
+++ b/test/services/orders/distribute_service_article_test.rb
@@ -383,6 +383,25 @@ class Orders::DistributeServiceArticleTest < ActiveSupport::TestCase
     end
   end
 
+  # === Completion guard: real, non-stubbed ===
+  #
+  # `CommerceHelpers#distribute_order!` neuters `all_transfers_generated?`
+  # so the suite can run at all. This test runs the service bare and asserts
+  # the guard itself — the only protection against a paid order re-entering
+  # `Orders::BatchDistributeJob`'s sweep every 10 minutes forever.
+
+  test "an article order completes through the real completion guard" do
+    with_quill_bot_stub do
+      order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+
+      Orders::DistributeService.call(order)
+
+      order.reload
+      assert order.transfers.exists?, "distribution should have created transfers"
+      assert order.completed?, "article order should complete once its revenue transfers exist"
+    end
+  end
+
   # === Per-reader share aggregation (one grouped query, not N) ===
 
   test "reader_revenue per-reader share is computed from a single grouped query, not N aggregate queries" do

--- a/test/services/orders/distribute_service_article_test.rb
+++ b/test/services/orders/distribute_service_article_test.rb
@@ -347,39 +347,73 @@ class Orders::DistributeServiceArticleTest < ActiveSupport::TestCase
 
   test "call is a no-op once the order is already completed" do
     with_quill_bot_stub do
-      with_all_transfers_generated! do
-        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
-        Orders::DistributeService.call(order)
-        assert order.reload.completed?
+      order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+      Orders::DistributeService.call(order)
+      assert order.reload.completed?
 
-        transfers_before = order.transfers.count
-        Orders::DistributeService.call(order)
-        assert_equal transfers_before, order.transfers.count,
-                     "re-running distribution on a completed order must not create transfers"
-      end
+      transfers_before = order.transfers.count
+      Orders::DistributeService.call(order)
+      assert_equal transfers_before, order.transfers.count,
+                   "re-running distribution on a completed order must not create transfers"
     end
   end
 
   test "concurrent calls generate transfers exactly once" do
     with_quill_bot_stub do
-      with_all_transfers_generated! do
-        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+      order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
 
-        threads = Array.new(4) do
-          Thread.new do
-            ActiveRecord::Base.connection_pool.with_connection do
-              Orders::DistributeService.call(Order.find(order.id))
-            end
+      threads = Array.new(4) do
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            Orders::DistributeService.call(Order.find(order.id))
           end
         end
-        threads.map(&:join)
-
-        order.reload
-        assert order.completed?, "order should be completed after distribution"
-        # quill_revenue transfer is keyed by a deterministic trace_id derived
-        # from the order, so it must exist exactly once regardless of caller count.
-        assert_equal 1, order.transfers.where(transfer_type: :quill_revenue).count
       end
+      threads.map(&:join)
+
+      order.reload
+      assert order.completed?, "order should be completed after distribution"
+      # quill_revenue transfer is keyed by a deterministic trace_id derived
+      # from the order, so it must exist exactly once regardless of caller count.
+      assert_equal 1, order.transfers.where(transfer_type: :quill_revenue).count
+    end
+  end
+
+  test "an article order funded by the platform wallet completes through the real guard" do
+    # Payment landed in the bot wallet: the bot fronts the payouts and keeps
+    # its own fee in place, so the transfers debit the bot wallet and sum to
+    # total minus the platform share — the guard's platform branch.
+    bot_client_id = QuillBotStub::FAKE_CLIENT_ID
+
+    with_quill_bot_stub(client_id: bot_client_id) do
+      snapshot = MixinNetworkSnapshot.create!(
+        snapshot_id: SecureRandom.uuid,
+        user_id: bot_client_id,
+        asset_id: @article.asset_id,
+        amount: 0,
+        trace_id: SecureRandom.uuid,
+        opponent_id: @reader_one.mixin_uuid,
+        transferred_at: Time.current,
+        data: ""
+      )
+
+      payment = create_payment!(
+        payer: @reader_one,
+        article: @article,
+        order_type: "BUY",
+        amount: @article.price
+      )
+      payment.update_columns(snapshot_id: snapshot.snapshot_id, trace_id: snapshot.trace_id)
+      order = payment.order
+      order.update_columns(trace_id: snapshot.trace_id)
+
+      Orders::DistributeService.call(order)
+
+      order.reload
+      assert order.completed?, "platform-funded article order should complete"
+      assert order.all_transfers_generated?
+      assert_nil order.transfers.find_by(transfer_type: :quill_revenue),
+                 "the platform should not transfer its own fee to itself"
     end
   end
 

--- a/test/support/commerce_helpers.rb
+++ b/test/support/commerce_helpers.rb
@@ -22,16 +22,10 @@ module CommerceHelpers
     originals&.each { |klass, method| klass.define_singleton_method(:with, method) }
   end
 
-  # `Orders::DistributeJob` re-fetches the order via `Order.find_by`, so
-  # per-instance stubs don't survive the re-fetch. Stub the AASM guard on the
-  # class for the test's duration and restore the original implementation.
-  ORIGINAL_ALL_TRANSFERS_GENERATED = Order.instance_method(:all_transfers_generated?)
-
-  def with_all_transfers_generated!
-    Order.define_method(:all_transfers_generated?) { true }
-    yield
-  ensure
-    Order.define_method(:all_transfers_generated?, ORIGINAL_ALL_TRANSFERS_GENERATED)
+  # Runs distribution for real — no stub. The service's completion guard
+  # (`Order#all_transfers_generated?`) is production code these tests rely on.
+  def distribute_order!(order)
+    order.distribute!
   end
 
   def build_payment_memo(type:, article: nil, collection: nil, citer: nil, follow_id: nil)


### PR DESCRIPTION
Closes #2070

## Confirmation first (commit 1, red on main)

The issue's first task was to prove the reading before changing anything. `test "an article order completes through the real completion guard"` runs `Orders::DistributeService` bare — no `all_transfers_generated?` stub — and asserts the order completes. **On main it fails**: transfers are created, the guard returns false, the order stays `paid`, and `Orders::BatchDistributeJob` re-enqueues it every 10 minutes forever. The suite never noticed because `distribute_order!` stubs the guard, and two tests asserted the stub.

## The seam, in one place

"Which wallet funds these payouts?" was decided in four places that had already diverged:

| Site | Before | After |
|---|---|---|
| `distribute_collection_order!` writers | `payment.wallet_id` | `payment.wallet_id` (unchanged) |
| `distribute_article_order!` writers | `QuillBot.api.client_id` via `distributor_wallet_id` | `payment.wallet_id` (verb default; `distributor_wallet_id` deleted) |
| quill-fee guards ×2 | `payment.wallet_id != QuillBot.api.client_id` | `!payment.platform_wallet?` |
| `Order#all_transfers_generated?` | sums `payment.wallet_id`, branches on inline `== client_id` | sums `payment.wallet_id`, branches on `payment.platform_wallet?` |

New: `Payment#platform_wallet?` — the one predicate answering "did the payment land in the bot wallet".

## The invariant, stated once

`Order#all_transfers_generated?` now says it in plain terms: *the revenue transfers that debit the funding wallet must sum to the full total — minus the platform's own share when the platform wallet funded the payment, since its fee never transfers to itself.*

**Production behavior is unchanged**: payments land in the bot wallet (`pre_order.rb` SAFE-pays `members: [QuillBot.api.client_id]`), so `payment.wallet_id` and the old `distributor_wallet_id` are the same value there. What changes is the unsupported/legacy case — a payment that landed elsewhere now completes correctly instead of re-enqueueing forever. The value-net doc's settlement paragraph is updated to match.

## De-stubbed test suite

- `distribute_order!` runs the **real** guard; `with_all_transfers_generated!` (class-level monkey-patch) and its stored original are deleted
- The order_test tautology (asserted the stub) is now a real negative→positive assertion: guard false before distribution, true after
- New platform-wallet-funded completion test (bot-wallet snapshot → quill transfer skipped → guard's platform branch → completes)
- The two former `with_all_transfers_generated!` call sites (job test, concurrency tests) now exercise the real guard — the concurrency test proves exactly-once transfer creation *with* real completion

## Known remaining edge (unchanged, noted)

A dust-scale order whose author remainder falls below `MINIMUM_AMOUNT` skips the author transfer, so the sum lands below the expectation and the guard stays false. Pre-existing behavior, untouched here — worth a tolerance decision in a follow-up if dust orders are ever real.

## Tests

Money-path suites: 80 runs, 175 assertions, 0 failures. Full suite: **1426 runs, 0 failures** (3 pre-existing skips). `bin/rubocop` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
