### PR TITLE
ci: refresh the apt index before installing system dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # Runner images no longer ship a pre-warmed apt index; without this
+          # every install below fails with "Unable to locate package".
+          sudo apt-get update
           sudo apt-get -yyq install libpq-dev
           # Install Chrome for system tests (Selenium WebDriver 4.x auto-manages the matching driver)
           if ! command -v google-chrome-stable &>/dev/null; then


### PR DESCRIPTION
## Problem

The `Check` workflow has failed at **Install system dependencies** on every recent run — including merged-to-main commits [#2079](https://github.com/baizhiheizi/quill/pull/2079), [#2080](https://github.com/baizhiheizi/quill/pull/2080) and the [#2081](https://github.com/baizhiheizi/quill/pull/2081) merge:

```
E: Unable to locate package wget
```

Root cause: the workflow runs three bare `sudo apt-get -yyq install …` calls (`libpq-dev`, `wget`, the Chrome `.deb`) and never runs `apt-get update`. Current runner images no longer ship a pre-warmed package index, so the first resolution fails.

## Fix

One line: `sudo apt-get update` at the top of the step (with a comment explaining why it must stay).

## Validation

- All substantive steps already pass locally via `bin/ci` (RuboCop, design-system lint, JS lint/tests, Rails suite, seeds, system tests) on current main — the only red was this infra step.
- The next run of this PR exercises the exact fix on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
